### PR TITLE
Allow a team to be omitted from the rankings

### DIFF
--- a/ctf/api.py
+++ b/ctf/api.py
@@ -221,10 +221,11 @@ def my_team(team):
 
 @bp.route('/team', methods=['PATCH'])
 @ensure_team
-@param('name', text_type)
-def rename_team(team, name):
+@param('name', text_type, optional=True)
+@param('hide_rank', bool, optional=True)
+def rename_team(team, name, hide_rank):
     try:
-        core.rename_team(team, name)
+        core.update_team(team, name, hide_rank)
     except CtfException as exc:
         abort(409, exc.message)
     return Response(status=204)

--- a/ctf/api.py
+++ b/ctf/api.py
@@ -22,27 +22,33 @@ for code in exceptions.default_exceptions.keys():
         bp.errorhandler(code)(handle_error)
 
 
-def param(key, desired_type=None):
+def get_json_value(data, key, desired_type, optional):
+    """Return data[key], with type checking."""
+    try:
+        value = data[key]
+    except (KeyError, TypeError):
+        if optional:
+            return None
+        abort(400, "Missing JSON value '{0}'.".format(key))
+
+    if desired_type is not None and not isinstance(value, desired_type):
+        if desired_type == text_type:
+            type_name = 'string'
+        else:
+            type_name = desired_type.__name__
+        abort(400, "Expected '{0}' to be type {1}.".format(key, type_name))
+
+    return value
+
+
+def param(key, desired_type=None, optional=False):
     """Return a decorator to parse a JSON request value."""
     def decorator(view_func):
         """The actual decorator"""
         @wraps(view_func)
         def inner(*args, **kwargs):
             data = request.get_json()  # May raise a 400
-            try:
-                value = data[key]
-            except (KeyError, TypeError):
-                abort(400, "Missing JSON value '{0}'.".format(key))
-            if desired_type and not isinstance(value, desired_type):
-                # For the error message
-                if desired_type == text_type:
-                    type_name = 'string'
-                else:
-                    type_name = desired_type.__name__
-                abort(400, ("Expected '{0}' to be type {1}."
-                            .format(key, type_name)))
-            # Success, pass through to view function
-            kwargs[key] = value
+            kwargs[key] = get_json_value(data, key, desired_type, optional)
             return view_func(*args, **kwargs)
         return inner
     return decorator

--- a/ctf/models.py
+++ b/ctf/models.py
@@ -30,6 +30,7 @@ class Team(db.Model):
     __tablename__ = 'team'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(128), unique=True)
+    hide_rank = db.Column(db.Boolean, default=False)
     invited = db.relationship('User', secondary=invite_table)
     challenges = db.relationship('Challenge', secondary='solve',
                                  backref='team', collection_class=set)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -135,11 +135,19 @@ def test_teams(app):
                 {'name': 'Hash Slinging Hackers'}, 201)
 
         # Team data
-        assert api_req(client.get, '/api/teams/1', key, 200) == {
+        assert api_req(client.get, '/api/teams/1', key, None, 200) == {
             'id': 1,
             'name': 'PPP',
             'points': 0,
         }
+
+        # Incorrect team id in URL
+        api_req(client.get, '/api/teams/3', key, None, 404, 'The requested ' +
+                'URL was not found on the server.  If you entered the URL ' +
+                'manually please check your spelling and try again.')
+
+        # Empty team patch
+        api_req(client.patch, '/api/team', key, {}, 204)
 
         # Can't rename to another team
         for name in ('PPP', 'Ppp'):
@@ -159,6 +167,14 @@ def test_teams(app):
             'teams': [
                 {'id': 1, 'name': 'PPP', 'points': 0},
                 {'id': 2, 'name': 'Hash Slinging Hackers', 'points': 0},
+            ],
+        }
+
+        # Hide team
+        api_req(client.patch, '/api/team', key, {'hide_rank': True}, 204)
+        assert api_req(client.get, '/api/teams/') == {
+            'teams': [
+                {'id': 1, 'name': 'PPP', 'points': 0},
             ],
         }
 


### PR DESCRIPTION
This closes #31.

This only contains the database and API portion of this change. This change does NOT include a UI change to allow users to toggle this setting on their own.