### PR TITLE
Allow a configurable redis URL

### DIFF
--- a/ctf/__init__.py
+++ b/ctf/__init__.py
@@ -22,7 +22,8 @@ def create_app():
     except ValueError:
         raise ValueError("The CTF configuration file was malformed")
 
-    app.redis = redis.StrictRedis()
+    redis_url = app.config.get('REDIS_URL', 'redis://localhost')
+    app.redis = redis.StrictRedis.from_url(redis_url)
 
     # Setup extensions
     ext.db.init_app(app)


### PR DESCRIPTION
This will let us configure how we connect to Redis.  For example, we could specify a password, or connect via a unix socket, rather than just have Redis listen on localhost with no password.