### PR TITLE
Use coalesce instead of non-standard ifnull

### DIFF
--- a/ctf/core.py
+++ b/ctf/core.py
@@ -30,8 +30,8 @@ def ensure_active():
 
 def get_teams():
     # This is pure mystical alchemy
-    q = (db.session.query(Team, db.func.ifnull(db.func.sum(Challenge.points),
-                                               0).label('points'))
+    q = (db.session.query(Team, db.func.coalesce(db.func.sum(Challenge.points),
+                                                 0).label('points'))
          .outerjoin(Solve).outerjoin(Challenge).group_by(Team.id)
          .order_by(db.desc('points'), db.func.min(Solve.earned_on), Team.id))
     return q.all()


### PR DESCRIPTION
``coalesce`` is the function we want to use. The ``ifnull`` function exists as a convenience function in SQLite (which is why our tests have been passing), but it is not standard SQL.

From the [SQLite docs](https://sqlite.org/lang_corefunc.html#ifnull):
> The ``ifnull()`` function is equivalent to ``coalesce()`` with two arguments.

The [MySQL docs](https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html) do not contain an ``ifnull`` function.

From the [PostgreSQL docs](https://www.postgresql.org/docs/9.2/static/functions-conditional.html):

> The ``COALESCE`` function returns the first of its arguments that is not null.
> ...
> This SQL-standard function provides capabilities similar to ``NVL`` and ``IFNULL``, which are used in some other database systems.