### PR TITLE
Remove extra challenge box padding. Closes #34

### DIFF
--- a/ctf/templates/challenge.html
+++ b/ctf/templates/challenge.html
@@ -6,7 +6,6 @@
 {%- endmacro %}
 
 {% block body %}
-<div class="container">
   {%- for chal in challenges %}
   <div class="panel
       {%- if chal in team.challenges %} panel-success
@@ -52,5 +51,4 @@
     </div>
   </div>
   {% endfor %}
-</div>
 {%- endblock %}


### PR DESCRIPTION
From ``base.html``:
```html
<div class="container">
  {%- block body %}{% end block %}
</div>
```

From ``challenge.html``:
```html
{% block body %}
  <div class="container"> ... </div>
{%- endblock %}
```

Markup in ``challenge.html`` was placed in a doubly-nested container div. This div adds 15px of padding for when the screen size is small, but this shifts the whole container right by 15px if it's in another fixed-width div. Since it was just in another container, we got 15px of unnecessary padding.