### PR TITLE
Make session cookies long-lasting

### DIFF
--- a/ctf/frontend.py
+++ b/ctf/frontend.py
@@ -113,6 +113,7 @@ def create_user():
         else:
             key = core.create_session_key(user)
             session['key'] = key
+            session.permanent = True
             return redirect_next(fallback=url_for('.home_page'), code=303)
     elif request.method == 'POST':
         # Attempted submit, but form validation failed
@@ -188,6 +189,7 @@ def login():
         else:
             key = core.create_session_key(user)
             session['key'] = key
+            session.permanent = True
             return redirect_next(fallback=url_for('.home_page'), code=303)
     flash_wtf_errors(form)
     return render_template('login.html', form=form), code


### PR DESCRIPTION
By default, Flask sessions last only for the duration of the browser session. Restart your browser, and you're logged out.

This changes makes sessions expire far in the future (31 days by default, unless changed with the ``PERMANENT_SESSION_LIFETIME`` Flask config value).