### PR TITLE
Clean up Team, use eager loading when appropriate

### DIFF
--- a/ctf/api.py
+++ b/ctf/api.py
@@ -190,8 +190,8 @@ def leaderboard():
         'teams': [{
             'id': team.id,
             'name': team.name,
-            'points': points,
-        } for team, points in teams],
+            'points': team.score,
+        } for team in teams],
     })
 
 
@@ -203,7 +203,7 @@ def get_team(id):
     return jsonify({
         'id': team.id,
         'name': team.name,
-        'points': team.get_points(),
+        'points': team.score,
     })
 
 

--- a/ctf/templates/home.html
+++ b/ctf/templates/home.html
@@ -10,11 +10,11 @@
         <th>#</th>
         <th>Team</th>
         <th>Points</th>
-        {%- for team, points in teams %}
+        {%- for team in teams %}
         <tr id="team{{ team.id }}">
           <td>{{ loop.index }}</td>
           <td><a href="{{ url_for('.team_page', id=team.id) }}">{{ team.name }}</a></td>
-          <td>{{ points }}</td>
+          <td>{{ team.score }}</td>
         </tr>
         {%- endfor %}
       </tbody>


### PR DESCRIPTION
This replaces the logic we were doing with `core.get_teams`.  Now, `Team.score` and `Team.last_solve` are computed columns from SQL expressions.  You can even use it in `order_by` like a normal column.

If you call `Team.query.all()`, it will just run:

```SQL
SELECT team.id AS team_id, team.name AS team_name FROM team
```

That's because `score` and `last_solve` are deferred. If you later attempt to access `score` for any of the returned Team objects, it will trigger the following query:

```SQL
SELECT coalesce(sum(challenge.points), 0) AS coalesce_1
FROM solve JOIN challenge ON solve.challenge_id = challenge.id
WHERE solve.team_id = team.id
```

You can choose to undefer these computed columns. We do this in `core.get_teams` to avoid an N+1. If you call `Team.query.options(undefer_group).all()`, it will run:

```SQL
SELECT (
    SELECT coalesce(sum(challenge.points), 0) AS coalesce_1
    FROM solve JOIN challenge ON solve.challenge_id = challenge.id
    WHERE solve.team_id = team.id
) AS anon_1, (
    SELECT max(solve.earned_on) AS max_1
    FROM solve
    WHERE solve.team_id = team.id
) AS anon_2, team.id AS team_id, team.name AS team_name
FROM team
```