### PR TITLE
Remove category from resource URL

### DIFF
--- a/ctf/api.py
+++ b/ctf/api.py
@@ -262,11 +262,10 @@ def challenge_info(team, id):
     return jsonify(ret)
 
 
-@bp.route('/file/<category>/<name>')
+@bp.route('/files/<name>')
 @ensure_team
-def get_resource(team, category, name):
-    resource = core.get_resource(team, category, name)
+def get_resource(team, name):
+    resource = core.get_resource(team, name)
     if resource is None:
         abort(404)
-    else:
-        return send_from_directory(resource.path, resource.name)
+    return send_from_directory(resource.path, resource.name)

--- a/ctf/core.py
+++ b/ctf/core.py
@@ -69,10 +69,8 @@ def get_challenge(team, id):
         return chal
 
 
-def get_resource(team, category, name):
-    resource = Resource.query.filter(Resource.name == name).\
-               join(Challenge).\
-               filter(Challenge.category == category).first()
+def get_resource(team, name):
+    resource = Resource.query.filter(Resource.name == name).first()
     if resource is None or not check_prereqs(team, resource.challenge):
         return None
     else:

--- a/ctf/frontend.py
+++ b/ctf/frontend.py
@@ -69,8 +69,7 @@ def challenge_page(team):
     resource_urls = {}
     for c in challenges:
         for r in c.resources:
-            resource_urls[r.name] = url_for('.get_resource',
-                                            category=c.category, name=r.name)
+            resource_urls[r.name] = url_for('.get_resource', name=r.name)
     return render_template('challenge.html', challenges=challenges,
                            team=team, form=form, resource_urls=resource_urls)
 
@@ -214,12 +213,11 @@ def snoopin():
     return redirect('https://www.youtube.com/watch?v=dQw4w9WgXcQ', code=303)
 
 
-@bp.route('/file/<category>/<name>/')
+@bp.route('/files/<name>')
 @ensure_team
-def get_resource(team, category, name):
-    resource = core.get_resource(team, category, name)
+def get_resource(team, name):
+    resource = core.get_resource(team, name)
     if resource is None:
         abort(404)
-    else:
-        return send_from_directory(resource.path, resource.name,
-                                   as_attachment=True)
+    return send_from_directory(resource.path, resource.name,
+                               as_attachment=True)

--- a/ctf/models.py
+++ b/ctf/models.py
@@ -64,6 +64,6 @@ class Challenge(db.Model):
 class Resource(db.Model):
     __tablename__ = "resource"
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(128))
+    name = db.Column(db.String(128), unique=True)
     path = db.Column(db.String(128))
     challenge_id = db.Column(db.Integer, db.ForeignKey('challenge.id'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -333,13 +333,13 @@ def test_resources(app):
 
         # Try to get file (which we'll compare with the file)
         test_file = open("tests/challenges/example/crypto.rb", 'r')
-        assert api_req(client.get, '/api/file/example/crypto.rb', user,
+        assert api_req(client.get, '/api/files/crypto.rb', user,
                        None, 200) == test_file.read()
         test_file.close()
 
         # Fail due to lack of team
-        api_req(client.get, '/api/file/example/crypto.rb', no_team_user, None,
+        api_req(client.get, '/api/files/crypto.rb', no_team_user, None,
                 403, 'You must be part of a team.')
 
         # Fail due to nx file
-        api_req(client.get, '/api/file/example/nx.rb', user, None, 404)
+        api_req(client.get, '/api/files/nx.rb', user, None, 404)


### PR DESCRIPTION
When we request a Resource, the URL contains the category. We then pulled the Resource from the database, joined it with all Challenges in the category from the URL, and took the first result of that join. We then ignored the Challenge from this result, and just used `resource.challenge` to check prereqs. So as long as the category existed at all, the request succeeded.

I've removed category from resource routes, and keep the behavior of using `resource.challenge` to check prereqs.

Since our old logic assumed uniqueness of Resource names, I also added that as a constraint on the column.

@atti1a does this reflect your original intention with this code?